### PR TITLE
Make package work as library as well as from command line.

### DIFF
--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -11,7 +11,7 @@ http://code.hanzoarchives.com/warc-tools/src/1897e2bc9d29/warcindex.py
 The functions that start with "get_" (as opposed to "parse_") are called by the
 dispatch loop in make_cdx using getattr().
 """
-from hanzo.warctools import ArchiveRecord #from https://bitbucket.org/rajbot/warc-tools
+from warctools import ArchiveRecord #from https://bitbucket.org/rajbot/warc-tools
 from surt      import surt          #from https://github.com/rajbot/surt
 
 import os


### PR DESCRIPTION
(I wasn't sure if this should be sent to @internetarchive or @rajbot -- let me know.)

This pull req. changes CDX-Writer so it can be imported from other Python packages, rather than assuming that it will run from the command line. (Writing to a file handle instead of calling print, throwing exceptions instead of calling sys.exit(), etc.)

It should still work from the command line as well, but I haven't tested that side of things.
