### PR TITLE
Migrate test scripts to py.test-based

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+tests/__pycache__

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ python:
   - "2.7"
 install:
   - pip install -r requirements.txt
-before_script:
-  - cd tests
+  - pip install pytest
 script:
-  - ./test_small_warcs.py
-  - ./test_excludes.py
+  - py.test

--- a/tests/test_large_warcs.py
+++ b/tests/test_large_warcs.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python
 
+import pytest
+import py
 import os
 import commands
 from pipes import quote
 
 warc_dir = '/warcs/'
+
+if not os.path.isdir(warc_dir):
+    pytest.skip(msg="requires large_warcs test dataset")
 
 warcs = {'YTV-20120204025848-crawl442/YTV-20120204035110-15431.warc.gz':                       '8be3352ac814c58e333d1a179e7e7951',
          'WIDE-20120121162724-crawl411/WIDE-20120121174231-03025.warc.gz':                     'c8e315322fa22f84f93f0abd0d414281',
@@ -12,22 +17,25 @@ warcs = {'YTV-20120204025848-crawl442/YTV-20120204035110-15431.warc.gz':        
          'wb_urls.ia11013.20050517055850-c/wb_urls.ia11013.20050805040525.arc.gz':             'f29414651eaced77184a048a2399477c', #missing filedesc:// header
         }
 
-for file, hash in warcs.iteritems():
-    assert not os.path.exists('tmp.cdx')
+testdir = py.path.local(__file__).dirpath()
+cdx_writer = str(testdir / '../cdx_writer.py')
 
-    warc_file = quote(warc_dir + file)
+@pytest.mark.parametrize(["file", "hash"], warcs.iteritems())
+def test_large_warcs(file, hash, tmpdir):
+    warc_file = os.path.join(warc_dir, file)
     assert os.path.exists(warc_file)
 
-    print "processing", warc_file
+    tmpcdx = tmpdir / 'tmp.cdx'
 
-    cmd = '/usr/bin/time --format=%e ' + '../cdx_writer.py %s >tmp.cdx' % warc_file
+    cmd = '/usr/bin/time --format=%e ' + '%s %s >%s' % (
+        cdx_writer, warc_file, tmpcdx)
     print "  running", cmd
     status, output = commands.getstatusoutput(cmd)
     assert 0 == status
     print 'time: ', output
     print 'size: ', os.path.getsize(warc_file)
 
-    cmd = 'md5sum tmp.cdx'
+    cmd = 'md5sum %s' % (tmpcdx,)
     print "  running", cmd
     status, output = commands.getstatusoutput(cmd)
     assert 0 == status
@@ -35,7 +43,3 @@ for file, hash in warcs.iteritems():
     warc_md5 = output.split()[0]
 
     assert hash == warc_md5
-
-    os.unlink('tmp.cdx')
-
-print "exiting without errors!"


### PR DESCRIPTION
  test_large_warcs is automatically skipped if /warcs does not exist
  no need to cd into tests
  test cases themselves remain the same.
  added a line for installing pytest to .travis.yml (not in requirements.txt)

(start of a series of changes toward easier testing)