### PR TITLE
Refactoring for making it easier to add support for more record types

### DIFF
--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -25,94 +25,334 @@ import json
 import urllib
 import urlparse
 from datetime  import datetime
+from operator import attrgetter
 from optparse  import OptionParser
+
+def to_unicode(s, charset):
+    if isinstance(s, str):
+        if charset is None:
+            #try utf-8 and hope for the best
+            s = s.decode('utf-8', 'replace')
+        else:
+            try:
+                s = s.decode(charset, 'replace')
+            except LookupError:
+                s = s.decode('utf-8', 'replace')
+    return s
+
+# these function used to be used for normalizing URL for ``redirect`` field.
+def urljoin_and_normalize(base, url, charset):
+    """urlparse.urljoin removes blank fragments (trailing #),
+    even if allow_fragments is set to True, so do this manually.
+
+    Also, normalize /../ and /./ in url paths.
+
+    Finally, encode spaces in the url with %20 so that we can
+    later split on whitespace.
+
+    Usage (run doctests with  `python -m doctest -v cdx_writer.py`):
+    >>> base = 'http://archive.org/a/b/'
+    >>> url  = '/c/d/../e/foo'
+    >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
+    http://archive.org/c/e/foo
+
+    urljoin() doesn't normalize if the url starts with a slash, and
+    os.path.normalize() has many issues, so normalize using regexes
+
+    >>> url = '/foo/./bar/#'
+    >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
+    http://archive.org/foo/bar/#
+
+    >>> base = 'http://archive.org'
+    >>> url = '../site'
+    >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
+    http://archive.org/site
+
+    >>> base = 'http://www.seomoz.org/page-strength/http://www.example.com/'
+    >>> url  = 'http://www.seomoz.org/trifecta/fetch/page/http://www.example.com/'
+    >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
+    http://www.seomoz.org/trifecta/fetch/page/http://www.example.com/
+    """
+
+    url  = to_unicode(url, charset)
+
+    #the base url is from the arc/warc header, which doesn't specify a charset
+    base = to_unicode(base, 'utf-8')
+
+    try:
+        joined_url = urlparse.urljoin(base, url)
+    except ValueError:
+        #some urls we find in arc files no longer parse with python 2.7,
+        #e.g. 'http://\x93\xe0\x90E\x83f\x81[\x83^\x93\xfc\x97\xcd.com/'
+        return '-'
+
+    # We were using os.path.normpath, but had to add too many patches
+    # when it was doing the wrong thing, such as turning http:// into http:/
+    m = re.match('(https?://.+?/)', joined_url)
+    if m:
+        domain = joined_url[:m.end(1)]
+        path   = joined_url[m.end(1):]
+        if path.startswith('../'):
+            path = path[3:]
+        norm_url = domain + re.sub('/[^/]+/\.\./', '/', path)
+        norm_url = re.sub('/\./', '/', norm_url)
+    else:
+        norm_url = joined_url
+
+    # deal with empty query strings and empty fragments, which
+    # urljoin sometimes removes
+    if url.endswith('?') and not norm_url.endswith('?'):
+        norm_url += '?'
+    elif url.endswith('#') and not norm_url.endswith('#'):
+        norm_url += '#'
+
+    #encode spaces
+    return norm_url.replace(' ', '%20')
 
 
 class ParseError(Exception):
     pass
 
-class CDX_Writer(object):
-    # init()
-    #___________________________________________________________________________
-    def __init__(self, file, out_file=sys.stdout, format="N b a m s k r M S V g", use_full_path=False, file_prefix=None, all_records=False, screenshot_mode=False, exclude_list=None, stats_file=None, canonicalizer_options=None):
+class RecordHandler(object):
+    def __init__(self, record, offset, cdx_writer):
+        """Defines default behavior for all fields.
+        Field values are defined as properties with name
+        matching descriptive name in ``field_map``.
+        """
+        self.record = record
+        self.offset = offset
+        self.cdx_writer = cdx_writer
+        self.urlkey = cdx_writer.urlkey
 
-        self.field_map = {'M': 'AIF meta tags',
-                          'N': 'massaged url',
-                          'S': 'compressed record size',
-                          'V': 'compressed arc file offset',
-                          'a': 'original url',
-                          'b': 'date',
-                          'g': 'file name',
-                          'k': 'new style checksum',
-                          'm': 'mime type',
-                          'r': 'redirect',
-                          's': 'response code',
-                         }
+    def get_record_header(self, name):
+        return self.record.get_header(name)
 
-        self.file   = file
-        self.out_file = out_file
-        self.format = format
-        self.all_records  = all_records
-        self.screenshot_mode = screenshot_mode
+    @property
+    def massaged_url(self):
+        """massaged url / field "N".
+        """
+        url = self.record.url
+        try:
+            return self.urlkey(url)
+        except:
+            return self.original_url
 
-        self.canonicalizer_options = canonicalizer_options or {}
+    @property
+    def date(self):
+        """date / field "b".
+        """
+        # warcs and arcs use a different date format
+        # consider using dateutil.parser instead
+        record = self.record
+        if record.date.isdigit():
+            date_len = len(record.date)
+            if 14 == date_len:
+                #arc record already has date in the format we need
+                return record.date
+            elif 16 == date_len:
+                #some arc records have 16-digit dates: 2000082305410049
+                return record.date[:14]
+            elif 18 == date_len:
+                #some arc records have 18-digit dates: 200009180023002953
+                return record.date[:14]
+            elif 12 == date_len:
+                #some arc records have 12-digit dates: 200011201434
+                return record.date + '00'
+        elif re.match('[a-f0-9]+$', record.date):
+            #some arc records have a hex string in the date field
+            return None
 
-        self.crlf_pattern = re.compile('\r?\n\r?\n')
-        self.response_pattern = re.compile('^application/http;\s*msgtype=response$', re.I)
+        #warc record
+        date = datetime.strptime(record.date, "%Y-%m-%dT%H:%M:%SZ")
+        return date.strftime("%Y%m%d%H%M%S")
 
-        #similar to what what the wayback uses:
-        self.fake_build_version = "archive-commons.0.0.1-SNAPSHOT-20120112102659-python"
+    def safe_url(self):
+        url = self.record.url
+        # There are few arc files from 2002 that have non-ascii characters in
+        # the url field. These are not utf-8 characters, and the charset of the
+        # page might not be specified, so use chardet to try and make these usable.
+        if isinstance(url, str):
+            try:
+                url.decode('ascii')
+            except UnicodeDecodeError:
+                enc = chardet.detect(url)
+                if enc and enc['encoding']:
+                    if 'EUC-TW' == enc['encoding']:
+                        # We don't have the EUC-TW encoding installed, and most likely
+                        # something is so wrong that we probably can't recover this url
+                        url = url.decode('Big5', 'replace')
+                    else:
+                        url = url.decode(enc['encoding'], 'replace')
+                else:
+                    url = url.decode('utf-8', 'replace')
 
-        #these fields are set for each record in the warc
-        self.offset        = 0
-        self.surt          = None
-        self.mime_type     = None
-        self.headers       = None
-        self.content       = None
-        self.meta_tags     = None
-        self.response_code = None
+        # Some arc headers contain urls with the '\r' character, which will cause
+        # problems downstream when trying to process this url, so escape it.
+        # While we are at it, replace other newline chars.
+        url = url.replace('\r', '%0D')
+        url = url.replace('\n', '%0A')
+        url = url.replace('\x0c', '%0C') #formfeed
+        url = url.replace('\x00', '%00') #null may cause problems with downstream C programs
 
-        #Large html files cause lxml to segfault
-        #problematic file was 154MB, we'll stop at 5MB
-        self.lxml_parse_limit = 5 * 1024 * 1024
+        return url
 
-        if use_full_path:
-            self.warc_path = os.path.abspath(file)
-        elif file_prefix:
-            self.warc_path = os.path.join(file_prefix, file)
-        else:
-            self.warc_path = file
+    @property
+    def original_url(self):
+        """original url / field "a".
+        """
+        url = self.safe_url()
+        return url.encode('utf-8')
 
-        if exclude_list:
-            if not os.path.exists(exclude_list):
-                raise IOError, "Exclude file not found"
-            self.excludes = []
-            f = open(exclude_list, 'r')
-            for line in f:
-                if '' == line.strip():
-                    continue
-                url = line.split()[0]
-                self.excludes.append(self.urlkey(url))
-        else:
-            self.excludes = None
+    @property
+    def mime_type(self):
+        """mime type / field "m".
+        """
+        return 'warc/' + self.record.type
 
-        if stats_file:
-            if os.path.exists(stats_file):
-                raise IOError, "Stats file already exists"
-            self.stats_file = stats_file
-        else:
-            self.stats_file = None
+    @property
+    def response_code(self):
+        """response code / field "s".
+        """
+        return None
 
-    def canonicalize(self, hurl):
-        return DefaultIAURLCanonicalizer.canonicalize(
-            hurl, **dict(self.canonicalizer_options))
+    @property
+    def new_style_checksum(self):
+        """new style checksum / field "k".
+        """
+        h = hashlib.sha1(self.record.content[1])
+        return base64.b32encode(h.digest())
 
-    def urlkey(self, url):
-        """compute urlkey from `url`."""
-        return surt(url, canonicalizer=self.canonicalize)
+    @property
+    def redirect(self):
+        """redirect / field "r".
+        """
+        # only meaningful for HTTP response records.
+        return None
 
-    # parse_http_header()
-    #___________________________________________________________________________
+    @property
+    def compressed_record_size(self):
+        """compressed record size / field "S".
+        """
+        size = self.record.compressed_record_size
+        if size is None:
+            return None
+        return str(size)
+
+    @property
+    def compressed_arc_file_offset(self):
+        """compressed arc file offset / field "V".
+        """
+        # TODO: offset attribute
+        return str(self.offset)
+
+    @property
+    def aif_meta_tags(self):
+        """AIF meta tags / field "M".
+        robot metatags, if present, should be in this order:
+        A, F, I. Called "robotsflags" in Wayback.
+        """
+        return None
+
+    @property
+    def file_name(self):
+        """file name / field "g".
+        """
+        return self.cdx_writer.warc_path
+
+class WarcinfoHandler(RecordHandler):
+    """``wercinfo`` record handler."""
+    #similar to what what the wayback uses:
+    fake_build_version = "archive-commons.0.0.1-SNAPSHOT-20120112102659-python"
+
+    @property
+    def massaged_url(self):
+        return self.original_url
+
+    @property
+    def original_url(self):
+        return 'warcinfo:/%s/%s' % (
+            self.cdx_writer.file, self.fake_build_version
+            )
+
+    @property
+    def mime_type(self):
+        return 'warc-info'
+
+class HttpHandler(RecordHandler):
+    """Logic common to all HTTP response records
+    (``response`` and ``revisit`` record types).
+    """
+    meta_tags = None
+
+    @property
+    def redirect(self):
+        # Aaron, Ilya, and Kenji have proposed using '-' in the redirect column
+        # unconditionally, after a discussion on Sept 5, 2012. It turns out the
+        # redirect column of the cdx has no effect on the Wayback Machine, and
+        # there were issues with parsing unescaped characters found in redirects.
+        return None
+
+        # followig code is copied from old version before refactoring. it will
+        # not work with new structure.
+
+        # response_code = self.response_code
+        #
+        # ## It turns out that the refresh tag is being used in both 2xx and 3xx
+        # ## responses, so always check both the http location header and the meta
+        # ## tags. Also, the java version passes spaces through to the cdx file,
+        # ## which might break tools that split cdx lines on whitespace.
+        #
+        # #only deal with 2xx and 3xx responses:
+        # #if 3 != len(response_code):
+        # #    return '-'
+        #
+        # charset = self.parse_charset()
+        #
+        # #if response_code.startswith('3'):
+        # location = self.parse_http_header('location')
+        # if location:
+        #     return self.urljoin_and_normalize(record.url, location, charset)
+        # #elif response_code.startswith('2'):
+        # if self.meta_tags and 'refresh' in self.meta_tags:
+        #     redir_loc = self.meta_tags['refresh']
+        #     m = re.search('\d+\s*;\s*url=(.+)', redir_loc, re.I) #url might be capitalized
+        #     if m:
+        #         return self.urljoin_and_normalize(record.url, m.group(1), charset)
+        #
+        # return '-'
+
+    def parse_charset(self):
+        charset = None
+
+        content_type = self.parse_http_header('content-type')
+        if content_type:
+            m = self.charset_pattern.search(content_type)
+            if m:
+                charset = m.group(1)
+
+        if charset is None and self.meta_tags is not None:
+            content_type = self.meta_tags.get('content-type')
+            if content_type:
+                m = self.charset_pattern.search(content_type)
+                if m:
+                    charset = m.group(1)
+
+        if charset:
+            charset = charset.replace('win-', 'windows-')
+
+        return charset
+
+class ResponseHandler(HttpHandler):
+    """Handler for HTTP response with archived content (``response`` record type).
+    """
+    def __init__(self, record, offset, cdx_writer):
+        super(ResponseHandler, self).__init__(record, offset, cdx_writer)
+        self.lxml_parse_limit = cdx_writer.lxml_parse_limit
+        self.headers, self.content = self.parse_headers_and_content()
+        self.meta_tags = self.parse_meta_tags()
+
+    response_pattern = re.compile('application/http;\s*msgtype=response$', re.I)
+
     def parse_http_header(self, header_name):
         if self.headers is None:
             return None
@@ -124,9 +364,7 @@ class CDX_Writer(object):
                 return m.group(1)
         return None
 
-    # parse_http_content_type_header()
-    #___________________________________________________________________________
-    def parse_http_content_type_header(self, record):
+    def parse_http_content_type_header(self):
         content_type = self.parse_http_header('content-type')
         if content_type is None:
             return 'unk'
@@ -140,40 +378,86 @@ class CDX_Writer(object):
         if m:
             content_type = m.group(1)
 
-        if re.match('^[a-z0-9\-\.\+/]+$', content_type):
+        if re.match('[a-z0-9\-\.\+/]+$', content_type):
             return content_type
         else:
             return 'unk'
 
+    charset_pattern = re.compile('charset\s*=\s*([a-z0-9_\-]+)', re.I)
 
-    # parse_charset()
-    #___________________________________________________________________________
-    def parse_charset(self):
-        charset = None
-        charset_pattern = re.compile('charset\s*=\s*([a-z0-9_\-]+)', re.I)
+    crlf_pattern = re.compile('\r?\n\r?\n')
 
-        content_type = self.parse_http_header('content-type')
-        if content_type:
-            m = charset_pattern.search(content_type)
-            if m:
-                charset = m.group(1)
+    def parse_headers_and_content(self):
+        """Returns a list of header lines, split with splitlines(), and the content.
+        We call splitlines() here so we only split once, and so \r\n and \n are
+        split in the same way.
+        """
+        if self.record.content[1].startswith('HTTP'):
+            # some records with empty HTTP payload end with just one CRLF or
+            # LF. If split fails, we assume this situation, and let content be
+            # an empty bytes, rather than None, so that payload digest is
+            # emitted correctly (see get_new_style_checksum method).
+            try:
+                headers, content = self.crlf_pattern.split(self.record.content[1], 1)
+            except ValueError:
+                headers = self.record.content[1]
+                content = ''
+            return headers.splitlines(), content
+        else:
+            return None, None
 
+    def is_response(self):
+        content_type = self.record.content_type
+        return content_type and self.response_pattern.match(content_type)
 
-        if charset is None and self.meta_tags is not None:
-            content_type = self.meta_tags.get('content-type')
-            if content_type:
-                m = charset_pattern.search(content_type)
-                if m:
-                    charset = m.group(1)
+    @property
+    def mime_type(self):
+        if self.is_response():
+            # WARC
+            return self.parse_http_content_type_header()
 
-        if charset:
-            charset = charset.replace('win-', 'windows-')
+        # For ARC record content_type returns response content type from
+        # ARC header line.
+        content_type = self.record.content_type
+        if content_type is None:
+            return 'unk'
 
-        return charset
+        # Alexa arc files use 'no-type' instead of 'unk'
+        if content_type == 'no-type':
+            return 'unk'
+        # if content_type contains non-ascii chars, return 'unk'
+        try:
+            content_type.decode('ascii')
+        except (LookupError, UnicodeDecodeError):
+            content_type = 'unk'
+        return content_type
 
-    # parse_meta_tags
-    #___________________________________________________________________________
-    def parse_meta_tags(self, record):
+    RE_RESPONSE_LINE = re.compile(r'HTTP(?:/\d\.\d)? (\d+)')
+
+    @property
+    def response_code(self):
+        m = self.RE_RESPONSE_LINE.match(self.record.content[1])
+        return m and m.group(1)
+
+    @property
+    def new_style_checksum(self):
+        if self.is_response():
+            digest = self.get_record_header('WARC-Payload-Digest')
+            return digest.replace('sha1:', '')
+        elif self.content is not None:
+            # This is an arc record. Our patched warctools fabricates the WARC-Payload-Digest
+            # header even for arc files so that we don't need to load large payloads in memory
+            digest = self.get_record_header('WARC-Payload-Digest')
+            if digest is not None:
+                return digest.replace('sha1:', '')
+            else:
+                h = hashlib.sha1(self.content)
+                return base64.b32encode(h.digest())
+        else:
+            h = hashlib.sha1(self.record.content[1])
+            return base64.b32encode(h.digest())
+
+    def parse_meta_tags(self):
         """We want to parse meta tags in <head>, even if not direct children.
         e.g. <head><noscript><meta .../></noscript></head>
 
@@ -183,7 +467,7 @@ class CDX_Writer(object):
         We use either the 'name' or 'http-equiv' attrib as the meta_tag dict key.
         """
 
-        if not ('response' == record.type and 'text/html' == self.mime_type):
+        if self.mime_type != 'text/html':
             return None
 
         if self.content is None:
@@ -197,7 +481,7 @@ class CDX_Writer(object):
             return meta_tags
 
         #lxml can't handle large documents
-        if record.content_length > self.lxml_parse_limit:
+        if self.record.content_length > self.lxml_parse_limit:
             return meta_tags
 
         # lxml was working great with ubuntu 10.04 / python 2.6
@@ -205,7 +489,6 @@ class CDX_Writer(object):
         # on the same warc files. Unfortunately, we don't ship a virtualenv,
         # so we're going to give up on lxml and use regexes to parse html :(
 
-        meta_tags = {}
         for x in re.finditer("(<meta[^>]+?>|</head>)", html_str, re.I):
             #we only want to look for meta tags that occur before the </head> tag
             if x.group(1).lower() == '</head>':
@@ -234,12 +517,8 @@ class CDX_Writer(object):
 
         return meta_tags
 
-
-    # get_AIF_meta_tags() //field "M"
-    #___________________________________________________________________________
-    def get_AIF_meta_tags(self, record):
-        """robot metatags, if present, should be in this order: A, F, I
-        """
+    @property
+    def aif_meta_tags(self):
         x_robots_tag = self.parse_http_header('x-robots-tag')
 
         robot_tags = []
@@ -262,7 +541,7 @@ class CDX_Writer(object):
         # of three values separated by comma. The first value is a number
         # of attempted logins (so >0 value means captured with login).
         # Example: ``1,1,http://(com,example,)/``
-        sfps = record.get_header('WARC-Simple-Form-Province-Status')
+        sfps = self.get_record_header('WARC-Simple-Form-Province-Status')
         if sfps:
             sfps = sfps.split(',', 2)
             try:
@@ -271,363 +550,162 @@ class CDX_Writer(object):
             except ValueError as ex:
                 pass
 
-        if s:
-            return ''.join(s)
+        return ''.join(s) if s else None
+
+class RevisitHandler(HttpHandler):
+    """HTTP revisit record (``revisit`` record type).
+
+    Note that this handler does not override ``mime_type``.
+    Hence ``mime_type`` field will always be ``warc/revisit``.
+    """
+    @property
+    def new_style_checksum(self):
+        digest = self.get_record_header('WARC-Payload-Digest')
+        if digest is None:
+            return None
+        return digest.replace('sha1:', '')
+
+class ScreenshotHandler(RecordHandler):
+    @property
+    def original_url(self):
+        return u'http://web.archive.org/screenshot/' + self.safe_url()
+
+    @property
+    def mime_type(self):
+        return record.content[0]
+
+class RecordDispatcher(object):
+    def __init__(self, all_records=False, screenshot_mode=False):
+        self.dispatchers = []
+        if screenshot_mode:
+            self.dispatchers.append(self.dispatch_screenshot)
         else:
-            return '-'
+            self.dispatchers.append(self.dispatch_http)
+
+        if all_records:
+            self.dispatchers.append(self.dispatch_other)
+
+    def dispatch_screenshot(self, record):
+        if (record.type == 'metadata' and
+            record.content_type.startswith('image/')):
+            return ScreenshotHandler
+        return None
+
+    def dispatch_http(self, record):
+        if record.content_type in ('text/dns',):
+            return None
+        if record.type == 'response':
+            return ResponseHandler
+        elif record.type == 'revisit':
+            return RevisitHandler
+        return None
 
 
-    # get_massaged_url() //field "N"
-    #___________________________________________________________________________
-    def get_massaged_url(self, record, use_precalculated_value=True):
-        if use_precalculated_value:
-            return self.surt
+    def dispatch_other(self, record):
+        if record.type == 'warcinfo':
+            return WarcinfoHandler
+        return RecordHandler
 
-        if 'warcinfo' == record.type:
-            return self.get_original_url(record)
-        else:
-            url = record.url
-            if self.screenshot_mode:
-                url = 'http://web.archive.org/screenshot/'+url
+    def get_handler(self, record, **kwargs):
+        for disp in self.dispatchers:
+            handler = disp(record)
+            if handler:
+                return handler(record, **kwargs)
+        return None
 
-            try:
-                return self.urlkey(url)
-            except:
-                return self.get_original_url(record)
+class CDX_Writer(object):
+    def __init__(self, file, out_file=sys.stdout, format="N b a m s k r M S V g", use_full_path=False, file_prefix=None, all_records=False, screenshot_mode=False, exclude_list=None, stats_file=None, canonicalizer_options=None):
+        """This class is instantiated for each web archive file and generates
+        CDX from it.
 
-
-    # get_compressed_record_size() //field "S"
-    #___________________________________________________________________________
-    def get_compressed_record_size(self, record):
-        size = record.compressed_record_size
-        if size is None:
-            size = "-"
-
-        return str(size)
-
-
-    # get_compressed_arc_file_offset() //field "V"
-    #___________________________________________________________________________
-    def get_compressed_arc_file_offset(self, record):
-        return str(self.offset)
-
-
-    # get_original_url() //field "a"
-    #___________________________________________________________________________
-    def get_original_url(self, record):
-        if 'warcinfo' == record.type:
-            url = 'warcinfo:/%s/%s' % (self.file, self.fake_build_version)
-            return url
-
-        url = record.url
-
-        # There are few arc files from 2002 that have non-ascii characters in
-        # the url field. These are not utf-8 characters, and the charset of the
-        # page might not be specified, so use chardet to try and make these usable.
-        if isinstance(url, str):
-            try:
-                url.decode('ascii')
-            except UnicodeDecodeError:
-                enc = chardet.detect(url)
-                if enc and enc['encoding']:
-                    if 'EUC-TW' == enc['encoding']:
-                        # We don't have the EUC-TW encoding installed, and most likely
-                        # something is so wrong that we probably can't recover this url
-                        url = url.decode('Big5', 'replace')
-                    else:
-                        url = url.decode(enc['encoding'], 'replace')
-                else:
-                    url = url.decode('utf-8', 'replace')
-
-        # Some arc headers contain urls with the '\r' character, which will cause
-        # problems downstream when trying to process this url, so escape it.
-        # While we are at it, replace other newline chars.
-        url = url.replace('\r', '%0D')
-        url = url.replace('\n', '%0A')
-        url = url.replace('\x0c', '%0C') #formfeed
-        url = url.replace('\x00', '%00') #null may cause problems with downstream C programs
-
-        if self.screenshot_mode:
-            url = u'http://web.archive.org/screenshot/' + url
-
-        return url
-
-    # get_date() //field "b"
-    #___________________________________________________________________________
-    def get_date(self, record):
-        #warcs and arcs use a different date format
-        #consider using dateutil.parser instead
-
-        if record.date.isdigit():
-            date_len = len(record.date)
-            if 14 == date_len:
-                #arc record already has date in the format we need
-                return record.date
-            elif 16 == date_len:
-                #some arc records have 16-digit dates: 2000082305410049
-                return record.date[:14]
-            elif 18 == date_len:
-                #some arc records have 18-digit dates: 200009180023002953
-                return record.date[:14]
-            elif 12 == date_len:
-                #some arc records have 12-digit dates: 200011201434
-                return record.date + '00'
-        elif re.match('^[a-f0-9]+$', record.date):
-            #some arc records have a hex string in the date field
-            return '-'
-
-        #warc record
-        date = datetime.strptime(record.date, "%Y-%m-%dT%H:%M:%SZ")
-        return date.strftime("%Y%m%d%H%M%S")
-
-    # get_file_name() //field "g"
-    #___________________________________________________________________________
-    def get_file_name(self, record):
-        return self.warc_path
-
-
-    # is_response()
-    #___________________________________________________________________________
-    def is_response(self, content_type):
-        if content_type is None:
-            return False
-
-        got_match = False
-        if self.response_pattern.match(content_type):
-            got_match = True
-
-        return got_match
-
-
-    # get_new_style_checksum() //field "k"
-    #___________________________________________________________________________
-    def get_new_style_checksum(self, record):
-        """Return a base32-encoded sha1
-        For revisit records, return the original sha1
+        :param file: input web archive file name
+        :param out_file: file object to write CDX to
+        :param format: CDX field specification string.
+        :param use_full_path: if ``True``, use absolute path of `file` for ``g``
+        :param file_prefix: prefix for `file` (effective only when `use_full_path`
+            is ``False``)
+        :param all_records: if ``True``, process all records
+        :param screenshot_mode: ``True`` turns on IA-proprietary screenshot mode
+        :param exclude_list: a file containing a list of excluded URLs
+        :param stat_file: a filename to write out statistics.
+        :param canonicalizer_options: URL canonicalizer options
         """
+        self.field_map = {'M': 'AIF meta tags',
+                          'N': 'massaged url',
+                          'S': 'compressed record size',
+                          'V': 'compressed arc file offset',
+                          'a': 'original url',
+                          'b': 'date',
+                          'g': 'file name',
+                          'k': 'new style checksum',
+                          'm': 'mime type',
+                          'r': 'redirect',
+                          's': 'response code',
+                         }
 
-        if 'revisit' == record.type:
-            digest = record.get_header('WARC-Payload-Digest')
-            if digest is None:
-                return '-'
-            else:
-                return digest.replace('sha1:', '')
-        elif 'response' == record.type and self.is_response(record.content_type):
-            digest = record.get_header('WARC-Payload-Digest')
-            #Our patched warc-tools fabricates this header if it is not present in the record
-            return digest.replace('sha1:', '')
-        elif 'response' == record.type and self.content is not None:
-            # This is an arc record. Our patched warctools fabricates the WARC-Payload-Digest
-            # header even for arc files so that we don't need to load large payloads in memory
-            digest = record.get_header('WARC-Payload-Digest')
-            if digest is not None:
-                return digest.replace('sha1:', '')
-            else:
-                h = hashlib.sha1(self.content)
-                return base64.b32encode(h.digest())
+        self.file   = file
+        self.out_file = out_file
+        self.format = format
+
+        self.fieldgetter = self._build_fieldgetter(self.format.split())
+
+        self.dispatcher = RecordDispatcher(
+            all_records=all_records, screenshot_mode=screenshot_mode)
+
+        self.canonicalizer_options = canonicalizer_options or {}
+
+        #Large html files cause lxml to segfault
+        #problematic file was 154MB, we'll stop at 5MB
+        self.lxml_parse_limit = 5 * 1024 * 1024
+
+        if use_full_path:
+            self.warc_path = os.path.abspath(file)
+        elif file_prefix:
+            self.warc_path = os.path.join(file_prefix, file)
         else:
-            h = hashlib.sha1(record.content[1])
-            return base64.b32encode(h.digest())
+            self.warc_path = file
 
-    # get_mime_type() //field "m"
-    #___________________________________________________________________________
-    def get_mime_type(self, record, use_precalculated_value=True):
-        """ See the WARC spec for more info on 'application/http; msgtype=response'
-        http://archive-access.sourceforge.net/warc/warc_file_format-0.16.html#anchor7
+        if exclude_list:
+            if not os.path.exists(exclude_list):
+                raise IOError("Exclude file not found")
+            self.excludes = []
+            with open(exclude_list, 'r') as f:
+                for line in f:
+                    if '' == line.strip():
+                        continue
+                    url = line.split()[0]
+                    self.excludes.append(self.urlkey(url))
+        else:
+            self.excludes = None
+
+        if stats_file:
+            if os.path.exists(stats_file):
+                raise IOError("Stats file already exists")
+            self.stats_file = stats_file
+        else:
+            self.stats_file = None
+
+    def _build_fieldgetter(self, fieldcodes):
+        """Return a callable that collects CDX field values from a
+        :class:`RecordHandler` object, according to CDX field specification
+        `fieldcodes`.
+
+        :param fieldcodes: a list of single-letter CDX field codes.
         """
+        attrs = []
+        for field in fieldcodes:
+            if field not in self.field_map:
+                raise ParseError('unknown field; {}'.format(field))
+            attrs.append(self.field_map[field].replace(' ', '_').lower())
+        return attrgetter(*attrs)
 
-        if use_precalculated_value:
-            return self.mime_type
+    def canonicalize(self, hurl):
+        return DefaultIAURLCanonicalizer.canonicalize(
+            hurl, **dict(self.canonicalizer_options))
 
-        if 'response' == record.type and self.is_response(record.content_type):
-            mime_type = self.parse_http_content_type_header(record)
-        elif 'response' == record.type:
-            if record.content_type is None:
-                mime_type = 'unk'
-            else:
-                #alexa arc files use 'no-type' instead of 'unk'
-                mime_type = record.content_type.replace('no-type', 'unk')
-        elif 'warcinfo' == record.type:
-            mime_type = 'warc-info'
-        elif self.screenshot_mode and 'metadata' == record.type:
-            mime_type = record.content[0]
-        else:
-            mime_type = 'warc/'+record.type
-
-        try:
-            mime_type = mime_type.decode('ascii')
-        except (LookupError, UnicodeDecodeError):
-            mime_type = u'unk'
-
-        return mime_type
-
-
-    # to_unicode()
-    #___________________________________________________________________________
-    @classmethod
-    def to_unicode(self, s, charset):
-        if isinstance(s, str):
-            if charset is None:
-                #try utf-8 and hope for the best
-                s = s.decode('utf-8', 'replace')
-            else:
-                try:
-                    s = s.decode(charset, 'replace')
-                except LookupError:
-                    s = s.decode('utf-8', 'replace')
-        return s
-
-    # urljoin_and_normalize()
-    #___________________________________________________________________________
-    @classmethod
-    def urljoin_and_normalize(self, base, url, charset):
-        """urlparse.urljoin removes blank fragments (trailing #),
-        even if allow_fragments is set to True, so do this manually.
-
-        Also, normalize /../ and /./ in url paths.
-
-        Finally, encode spaces in the url with %20 so that we can
-        later split on whitespace.
-
-        Usage (run doctests with  `python -m doctest -v cdx_writer.py`):
-        >>> base = 'http://archive.org/a/b/'
-        >>> url  = '/c/d/../e/foo'
-        >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
-        http://archive.org/c/e/foo
-
-        urljoin() doesn't normalize if the url starts with a slash, and
-        os.path.normalize() has many issues, so normalize using regexes
-
-        >>> url = '/foo/./bar/#'
-        >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
-        http://archive.org/foo/bar/#
-
-        >>> base = 'http://archive.org'
-        >>> url = '../site'
-        >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
-        http://archive.org/site
-
-        >>> base = 'http://www.seomoz.org/page-strength/http://www.example.com/'
-        >>> url  = 'http://www.seomoz.org/trifecta/fetch/page/http://www.example.com/'
-        >>> print CDX_Writer.urljoin_and_normalize(base, url, 'utf-8')
-        http://www.seomoz.org/trifecta/fetch/page/http://www.example.com/
-        """
-
-        url  = self.to_unicode(url, charset)
-
-        #the base url is from the arc/warc header, which doesn't specify a charset
-        base = self.to_unicode(base, 'utf-8')
-
-        try:
-            joined_url = urlparse.urljoin(base, url)
-        except ValueError:
-            #some urls we find in arc files no longer parse with python 2.7,
-            #e.g. 'http://\x93\xe0\x90E\x83f\x81[\x83^\x93\xfc\x97\xcd.com/'
-            return '-'
-
-        # We were using os.path.normpath, but had to add too many patches
-        # when it was doing the wrong thing, such as turning http:// into http:/
-        m = re.match('(https?://.+?/)', joined_url)
-        if m:
-            domain = joined_url[:m.end(1)]
-            path   = joined_url[m.end(1):]
-            if path.startswith('../'):
-                path = path[3:]
-            norm_url = domain + re.sub('/[^/]+/\.\./', '/', path)
-            norm_url = re.sub('/\./', '/', norm_url)
-        else:
-            norm_url = joined_url
-
-        # deal with empty query strings and empty fragments, which
-        # urljoin sometimes removes
-        if url.endswith('?') and not norm_url.endswith('?'):
-            norm_url += '?'
-        elif url.endswith('#') and not norm_url.endswith('#'):
-            norm_url += '#'
-
-        #encode spaces
-        return norm_url.replace(' ', '%20')
-
-
-    # get_redirect() //field "r"
-    #___________________________________________________________________________
-    def get_redirect(self, record):
-        """Aaron, Ilya, and Kenji have proposed using '-' in the redirect column
-        unconditionally, after a discussion on Sept 5, 2012. It turns out the
-        redirect column of the cdx has no effect on the Wayback Machine, and
-        there were issues with parsing unescaped characters found in redirects.
-        """
-        return '-'
-
-        # response_code = self.response_code
-        #
-        # ## It turns out that the refresh tag is being used in both 2xx and 3xx
-        # ## responses, so always check both the http location header and the meta
-        # ## tags. Also, the java version passes spaces through to the cdx file,
-        # ## which might break tools that split cdx lines on whitespace.
-        #
-        # #only deal with 2xx and 3xx responses:
-        # #if 3 != len(response_code):
-        # #    return '-'
-        #
-        # charset = self.parse_charset()
-        #
-        # #if response_code.startswith('3'):
-        # location = self.parse_http_header('location')
-        # if location:
-        #     return self.urljoin_and_normalize(record.url, location, charset)
-        # #elif response_code.startswith('2'):
-        # if self.meta_tags and 'refresh' in self.meta_tags:
-        #     redir_loc = self.meta_tags['refresh']
-        #     m = re.search('\d+\s*;\s*url=(.+)', redir_loc, re.I) #url might be capitalized
-        #     if m:
-        #         return self.urljoin_and_normalize(record.url, m.group(1), charset)
-        #
-        # return '-'
-
-    # get_response_code() //field "s"
-    #___________________________________________________________________________
-    def get_response_code(self, record, use_precalculated_value=True):
-        if use_precalculated_value:
-            return self.response_code
-
-        if 'response' != record.type:
-            return '-'
-
-        m = re.match("HTTP(?:/\d\.\d)? (\d+)", record.content[1])
-        if m:
-            return m.group(1)
-        else:
-            return '-'
-
-    # split_headers_and_content()
-    #___________________________________________________________________________
-    def parse_headers_and_content(self, record):
-        """Returns a list of header lines, split with splitlines(), and the content.
-        We call splitlines() here so we only split once, and so \r\n and \n are
-        split in the same way.
-        """
-
-        if 'response' == record.type and record.content[1].startswith('HTTP'):
-            # some records with empty HTTP payload end with just one CRLF or
-            # LF. If split fails, we assume this situation, and let content be
-            # an empty bytes, rather than None, so that payload digest is
-            # emitted correctly (see get_new_style_checksum method).
-            try:
-                headers, content = self.crlf_pattern.split(record.content[1], 1)
-            except ValueError:
-                headers = record.content[1]
-                content = ''
-            headers = headers.splitlines()
-        elif  self.screenshot_mode and 'metadata' == record.type:
-            headers = None
-            content = record.content[1]
-        else:
-            headers = None
-            content = None
-
-        return headers, content
-
+    def urlkey(self, url):
+        """compute urlkey from `url`."""
+        return surt(url, canonicalizer=self.canonicalize)
 
     # should_exclude()
     #___________________________________________________________________________
@@ -647,12 +725,7 @@ class CDX_Writer(object):
     def make_cdx(self):
         if isinstance(self.out_file, basestring):
             self.out_file = open(self.out_file, 'wb')
-        self.out_file.write(' CDX ' + self.format + '\n') #print header
-
-        if not self.all_records:
-            #filter cdx lines if --all-records isn't specified
-            allowed_record_types     = set(['response', 'revisit'])
-            disallowed_content_types = set(['text/dns'])
+        self.out_file.write(b' CDX ' + self.format + b'\n') #print header
 
         stats = {
             'num_records_processed': 0,
@@ -662,67 +735,46 @@ class CDX_Writer(object):
 
         fh = ArchiveRecord.open_archive(self.file, gzip="auto", mode="r")
         for (offset, record, errors) in fh.read_records(limit=None, offsets=True):
-            self.offset = offset
+            if not record:
+                if errors:
+                    raise ParseError(str(errors))
+                continue # tail
 
-            if record:
-                stats['num_records_processed'] += 1
-                if self.screenshot_mode:
-                    if record.type != 'metadata':
-                        continue
-                elif not self.all_records and (record.type not in allowed_record_types or record.content_type in disallowed_content_types):
-                    continue
+            stats['num_records_processed'] += 1
+            handler = self.dispatcher.get_handler(record, offset=offset, cdx_writer=self)
+            if not handler:
+                continue
 
-                ### arc files from the live web proxy can have a negative content length and a missing payload
-                ### check the content_length from the arc header, not the computed payload size returned by record.content_length
-                content_length_str = record.get_header(record.CONTENT_LENGTH)
-                if content_length_str is not None and int(content_length_str) < 0:
-                    continue
+            ### arc files from the live web proxy can have a negative content length and a missing payload
+            ### check the content_length from the arc header, not the computed payload size returned by record.content_length
+            content_length_str = record.get_header(record.CONTENT_LENGTH)
+            if content_length_str is not None and int(content_length_str) < 0:
+                continue
 
-                self.surt = self.get_massaged_url(record, use_precalculated_value=False)
-                if self.should_exclude(self.surt):
-                    stats['num_records_filtered'] += 1
-                    continue
+            surt = handler.massaged_url
+            if self.should_exclude(surt):
+                stats['num_records_filtered'] += 1
+                continue
 
-                ### precalculated data that is used multiple times
-                self.headers, self.content = self.parse_headers_and_content(record)
-                self.mime_type             = self.get_mime_type(record, use_precalculated_value=False)
-                self.response_code         = self.get_response_code(record, use_precalculated_value=False)
-                self.meta_tags             = self.parse_meta_tags(record)
+            ### precalculated data that is used multiple times
+            # self.headers, self.content = self.parse_headers_and_content(record)
+            # self.mime_type             = self.get_mime_type(record, use_precalculated_value=False)
 
-                s = u''
-                for field in self.format.split():
-                    if not field in self.field_map:
-                        raise ParseError('Unknown field: ' + field)
-
-                    endpoint = self.field_map[field].replace(' ', '_')
-                    response = getattr(self, 'get_' + endpoint)(record)
-                    #print self.offset
-                    #print record.compressed_record_size
-                    #print record.content_length
-                    #print record.headers
-                    #print len(self.content)
-                    #print repr(record.content[1])
-                    #print endpoint
-                    #print repr(response)
-                    s += response + ' '
-                self.out_file.write(s.rstrip().encode('utf-8')+'\n')
-                #record.dump()
-                stats['num_records_included'] += 1
-            elif errors:
-                raise ParseError(str(errors))
-            else:
-                pass # tail
+            values = [b'-' if v is None else v for v in self.fieldgetter(handler)]
+            self.out_file.write(b' '.join(values) + b'\n')
+            #record.dump()
+            stats['num_records_included'] += 1
 
         fh.close()
 
         if self.stats_file is not None:
-            f = open(self.stats_file, 'w')
-            json.dump(stats, f, indent=4)
-            f.close()
+            with open(self.stats_file, 'w') as f:
+                json.dump(stats, f, indent=4)
+
 
 # main()
 #_______________________________________________________________________________
-if __name__ == '__main__':
+def main(args):
 
     parser = OptionParser(usage="%prog [options] warc.gz [output_file.cdx]")
     parser.set_defaults(format        = "N b a m s k r M S V g",
@@ -747,14 +799,14 @@ if __name__ == '__main__':
                       action='append_const', const=('host_massage', False),
                       help='Turn off host_massage (ex. stripping "www.")')
 
-    (options, input_files) = parser.parse_args(args=sys.argv[1:])
+    options, input_files = parser.parse_args(args=args)
 
     if len(input_files) != 2:
         if len(input_files) == 1:
             input_files.append(sys.stdout)
         else:
             parser.print_help()
-            exit(-1)
+            return -1
 
     cdx_writer = CDX_Writer(input_files[0], input_files[1],
                             format=options.format,
@@ -768,3 +820,7 @@ if __name__ == '__main__':
                             options.canonicalizer_options
                            )
     cdx_writer.make_cdx()
+    return 0
+
+if __name__ == '__main__':
+    exit(main(sys.argv[1:]))

--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -571,7 +571,7 @@ class RevisitHandler(HttpHandler):
 class ScreenshotHandler(RecordHandler):
     @property
     def original_url(self):
-        return u'http://web.archive.org/screenshot/' + self.safe_url()
+        return 'http://web.archive.org/screenshot/' + self.safe_url()
 
     @property
     def mime_type(self):

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -1,0 +1,97 @@
+from __future__ import unicode_literals
+import sys
+import py
+sys.path[0:0] = (str(py.path.local(__file__) / '../..'),)
+
+import pytest
+import hashlib
+import base64
+
+import io
+from gzip import GzipFile
+from cdx_writer import CDX_Writer
+from hanzo.warctools import WarcRecord
+
+def create_metadata_record_bytes(
+    url='http://example.com/',
+    content_type='image/png',
+    date='2016-08-03T10:49:41Z',
+    content=b'',
+    include_block_digest=True):
+    """Build WARC metadata record bits."""
+
+    headers = {
+        WarcRecord.TYPE: WarcRecord.METADATA,
+        WarcRecord.URL: url.encode('utf-8'),
+        WarcRecord.CONTENT_TYPE: content_type.encode('utf-8'),
+        WarcRecord.DATE: date.encode('utf-8')
+        }
+    if include_block_digest:
+        hasher = hashlib.sha1(content)
+        block_digest = base64.b32encode(hasher.digest())
+        headers[WarcRecord.BLOCK_DIGEST] = b'sha1:' + block_digest
+
+    # XXX - I wish I could use WarcRecord. Current implementation of
+    # WarcRecord.write_to() ignores Warc-Block-Digest passed and writes out
+    # hex-encoded SHA256 calculated from the content.
+    out = io.BytesIO()
+    if False:
+        rec = WarcRecord(
+            headers=headers.items(),
+            content=(content_type.encode('utf-8'), content)
+            )
+        out = io.BytesIO()
+        rec.write_to(out, gzip=True)
+        return out.getvalue()
+    else:
+        z = GzipFile(fileobj=out, mode='wb')
+        z.write(b'WARC/1.0\r\n')
+        for k, v in headers.items():
+            z.write(b''.join((k, b': ', v, b'\r\n')))
+        z.write('Content-Length: {}\r\n'.format(len(content)).encode('ascii'))
+        z.write(b'\r\n')
+        z.write(content)
+        z.write(b'\r\n\r\n')
+        z.flush()
+        z.close()
+        return out.getvalue()
+
+@pytest.mark.parametrize("block_digest", [ True, False ])
+def test_sceenshot_regular(block_digest, tmpdir):
+    """IA-proprietary screen capture archive format:
+    PNG image is archived as ``metadata`` record. ``Content-Type`` is
+    ``image/png``, and SHA1 digest is in ``WARC-Block-Digest``.
+    data block is the screen capture image itself.
+
+    If record has no WARC-Block_Digest (block_digest==False), CDX_Writer shall
+    compute SHA1 digest on its own.
+    """
+    # fake screenshot data
+    payload = b'\x01' * 128
+    payload_digest = base64.b32encode(hashlib.sha1(payload).digest())
+
+    recbits = create_metadata_record_bytes(content=payload, include_block_digest=block_digest)
+    warc = tmpdir / 'test.warc.gz'
+    warc.write(recbits, mode='wb')
+    reclen = len(recbits)
+
+    cdxout = tmpdir / 'test.cdx'
+    with tmpdir.as_cwd():
+        cdx_writer = CDX_Writer(warc.basename, cdxout.basename, screenshot_mode=True)
+        cdx_writer.make_cdx()
+
+    assert cdxout.isfile()
+    cdx =  cdxout.readlines() # utf-8 decoded
+    assert len(cdx) == 2
+    cdx1 = cdx[1].rstrip().split(' ')
+    assert cdx1 == [
+        'com,example)/',
+        '20160803104941',
+        'http://web.archive.org/screenshot/http://example.com/',
+        'image/png',
+        '-', # statuscode is undefined
+        payload_digest,
+        '-', '-',
+        format(reclen), '0',
+        warc.basename
+        ]


### PR DESCRIPTION
This is a major refactoring to facilitate future extension (here _record type_ means `WARC-Type` plus other features of the record).

Current field value methods (such as `get_mime_type`) have repeated conditionals on record-type. It is harder to follow how each record type is processed, and we need to touch multiple methods to add support for new record types.

After refactoring, field value method are organized by record type in `RecordHandler` sub-classes. `RecordDispatcher` picks specific RecordHandler sub-class based on the record features. Now supporting new record type is as easy as defining new RecordHandler and adding a dispatcher for it.  It is also easy to enable/disable processing of certain record types.

field value methods are changed into properties, as it is easier to access with `attrgetter`, which is pre-computed once for all CDX lines (current code runs lookup for every CDX line). 

field value methods return `bytes`, not `unicode`. `RecordHandler.safe_url()` still checks URL for non-ascii characters -- this code appears to be harmful, and should be removed (unchanged in this patch so as not to change external behavior).