### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: python
 python:
   - "2.7"
   - "3.8"
+jobs:
+  allow_failures:
+    - python: "3.8"
 install:
   - pip install flake8 pytest -r requirements.txt .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+os: linux
+dist: focal
 language: python
 python:
   - "2.7"
+  - "3.8"
 install:
-  - pip install -r requirements.txt .
-  - pip install pytest
+  - pip install flake8 pytest -r requirements.txt .
 script:
-  - py.test
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  - pytest

--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -702,13 +702,13 @@ class RecordDispatcher(object):
         return None
 
 class CDX_Writer(object):
-    def __init__(self, file, out_file=sys.stdout, format="N b a m s k r M S V g", use_full_path=False, file_prefix=None, all_records=False, screenshot_mode=False, exclude_list=None, stats_file=None, canonicalizer_options=None):
+    def __init__(self, file, out_file=sys.stdout, format=b"N b a m s k r M S V g", use_full_path=False, file_prefix=None, all_records=False, screenshot_mode=False, exclude_list=None, stats_file=None, canonicalizer_options=None):
         """This class is instantiated for each web archive file and generates
         CDX from it.
 
         :param file: input web archive file name
         :param out_file: file object to write CDX to
-        :param format: CDX field specification string.
+        :param format: CDX field specification bytes.
         :param use_full_path: if ``True``, use absolute path of `file` for ``g``
         :param file_prefix: prefix for `file` (effective only when `use_full_path`
             is ``False``)

--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -702,13 +702,13 @@ class RecordDispatcher(object):
         return None
 
 class CDX_Writer(object):
-    def __init__(self, file, out_file=sys.stdout, format=b"N b a m s k r M S V g", use_full_path=False, file_prefix=None, all_records=False, screenshot_mode=False, exclude_list=None, stats_file=None, canonicalizer_options=None):
+    def __init__(self, file, out_file=sys.stdout, format="N b a m s k r M S V g", use_full_path=False, file_prefix=None, all_records=False, screenshot_mode=False, exclude_list=None, stats_file=None, canonicalizer_options=None):
         """This class is instantiated for each web archive file and generates
         CDX from it.
 
         :param file: input web archive file name
         :param out_file: file object to write CDX to
-        :param format: CDX field specification bytes.
+        :param format: CDX field specification string.
         :param use_full_path: if ``True``, use absolute path of `file` for ``g``
         :param file_prefix: prefix for `file` (effective only when `use_full_path`
             is ``False``)
@@ -733,7 +733,7 @@ class CDX_Writer(object):
 
         self.file   = file
         self.out_file = out_file
-        self.format = format
+        self.format = format.encode('utf-8')
 
         self.fieldgetter = self._build_fieldgetter(self.format.split())
 

--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -26,6 +26,11 @@ from datetime import datetime
 from operator import attrgetter
 from optparse import OptionParser
 
+try:
+    basestring
+except NameError:
+    basestring = str
+
 def to_unicode(s, charset):
     if isinstance(s, str):
         if charset is None:

--- a/cdx_writer.py
+++ b/cdx_writer.py
@@ -21,10 +21,15 @@ import base64
 import chardet
 import hashlib
 import json
-import urlparse
+
 from datetime import datetime
 from operator import attrgetter
 from optparse import OptionParser
+
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
 
 try:
     basestring
@@ -45,7 +50,7 @@ def to_unicode(s, charset):
 
 # these function used to be used for normalizing URL for ``redirect`` field.
 def urljoin_and_normalize(base, url, charset):
-    """urlparse.urljoin removes blank fragments (trailing #),
+    """urljoin removes blank fragments (trailing #),
     even if allow_fragments is set to True, so do this manually.
 
     Also, normalize /../ and /./ in url paths.
@@ -83,7 +88,7 @@ def urljoin_and_normalize(base, url, charset):
     base = to_unicode(base, 'utf-8')
 
     try:
-        joined_url = urlparse.urljoin(base, url)
+        joined_url = urljoin(base, url)
     except ValueError:
         #some urls we find in arc files no longer parse with python 2.7,
         #e.g. 'http://\x93\xe0\x90E\x83f\x81[\x83^\x93\xfc\x97\xcd.com/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-https://github.com/internetarchive/warctools/archive/cdx-writer.tar.gz
-surt==0.3.1; python_version < '3.0'
-git+git://github.com/internetarchive/surt@master; python_version >= '3.0'
+# https://github.com/internetarchive/warctools/archive/cdx-writer.tar.gz
+surt==0.3.1
+git+git://github.com/internetarchive/warctools@master
 chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# https://github.com/internetarchive/warctools/archive/cdx-writer.tar.gz
+https://github.com/internetarchive/warctools/archive/cdx-writer.tar.gz; python_version < '3.0'
+git+git://github.com/internetarchive/warctools@master; python_version >= '3.0'
 surt==0.3.1
-git+git://github.com/internetarchive/warctools@master
 chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 https://github.com/internetarchive/warctools/archive/cdx-writer.tar.gz
-surt==0.3.1
+surt==0.3.1; python_version < '3.0'
+git+git://github.com/internetarchive/surt@master; python_version >= '3.0'
 chardet

--- a/tests/clean_the_banlist.py
+++ b/tests/clean_the_banlist.py
@@ -34,6 +34,7 @@ Here is the incomplete list of regexes for stripping prefixes, which is no longe
                 r'^http://web.archive.bibalex.orgyweb/\d{14}/',
                 ]
 """
+from __future__ import print_function
 
 import sys
 import re
@@ -88,7 +89,7 @@ def remove_prefix(s):
 
     result = urlparse.urlparse(s)
     if not (('archive.org' in result.netloc) or ('bibalex.org' in result.netloc) or ('waybackmachine.org' in result.netloc)):
-        print 'unable to parse url:', s, orig_s
+        print('unable to parse url:', s, orig_s)
         sys.exit(-1)
 
     start_pos = result.path.find('http://')
@@ -109,7 +110,7 @@ def remove_prefix(s):
         if match:
             s = match.group(1)
         else:
-            print 'unable to find match for url:', s
+            print('unable to find match for url:', s)
             sys.exit(-1)
     else:
         s = result.path[start_pos:]
@@ -148,15 +149,15 @@ urls.sort()
 
 for url in urls:
     if ('archive.org' in url) or ('bibalex.org' in url) or ('waybackmachine.org' in url):
-        print 'unfiltered url:', url
+        print('unfiltered url:', url)
         sys.exit(-1)
 
     if comment:
         url += ' #'+comment
 
     try:
-        print url.encode('ascii')
+        print(url.encode('ascii'))
     except:
-        print 'UnicodeError', 'BAD URL: '+repr(url)
-        print 'terminating'
+        print('UnicodeError', 'BAD URL: '+repr(url))
+        print('terminating')
         sys.exit(-1)

--- a/tests/test_large_warcs.py
+++ b/tests/test_large_warcs.py
@@ -8,7 +8,6 @@ import py
 import sys
 import os
 import re
-import commands
 import subprocess
 from pipes import quote
 from hashlib import md5
@@ -68,7 +67,7 @@ def test_large_warcs(data, tmpdir):
         cdx_writer, warc_fn, tmpcdx)
     print("  running", cmd)
     with py.path.local(warc_dir).as_cwd():
-        status, output = commands.getstatusoutput(cmd)
+        status, output = subprocess.getstatusoutput(cmd)
     assert 0 == status
     print('time: ', output)
     print('size: ', os.path.getsize(warc_file))
@@ -82,7 +81,7 @@ def test_large_warcs(data, tmpdir):
     if os.path.exists(exp):
         cmd = 'diff -u %r %r' % (exp, str(tmphashcdx))
         print("  running", cmd)
-        status, output = commands.getstatusoutput(cmd)
+        status, output = subprocess.getstatusoutput(cmd)
         print(output)
         assert 0 == status
 
@@ -152,7 +151,7 @@ if __name__ == "__main__":
                    " https://archive.org/download/%s" % (
                     args.cookie, warc_file, w['fn']))
             print("Running %s" % (cmd,), file=sys.stderr)
-            status, output = commands.getstatusoutput(cmd)
+            status, output = subprocess.getstatusoutput(cmd)
             assert status == 0, "Download failed with status=%d" % (status,)
 
             sys.stderr.write("Checking checksum...")

--- a/tests/test_large_warcs.py
+++ b/tests/test_large_warcs.py
@@ -2,6 +2,7 @@
 """
 Test cdx_writer.py with real-world W/ARCs.
 """
+from __future__ import print_function
 import pytest
 import py
 import sys
@@ -65,12 +66,12 @@ def test_large_warcs(data, tmpdir):
 
     cmd = TIMECMD + '%s %s >%s' % (
         cdx_writer, warc_fn, tmpcdx)
-    print "  running", cmd
+    print("  running", cmd)
     with py.path.local(warc_dir).as_cwd():
         status, output = commands.getstatusoutput(cmd)
     assert 0 == status
-    print 'time: ', output
-    print 'size: ', os.path.getsize(warc_file)
+    print('time: ', output)
+    print('size: ', os.path.getsize(warc_file))
 
     # translate CDX output into expected data format
     tmphashcdx = tmpdir / 'tmp.hashcdx'
@@ -80,9 +81,9 @@ def test_large_warcs(data, tmpdir):
     exp = os.path.join(data_dir, re.sub(r'\.w?arc\.gz$', '.exp', warc_fn))
     if os.path.exists(exp):
         cmd = 'diff -u %r %r' % (exp, str(tmphashcdx))
-        print "  running", cmd
+        print("  running", cmd)
         status, output = commands.getstatusoutput(cmd)
-        print output
+        print(output)
         assert 0 == status
 
     if expected_cdx_md5:
@@ -123,8 +124,8 @@ if __name__ == "__main__":
             outdir = os.path.dirname(out_file)
             if not os.path.isdir(outdir):
                 os.makedirs(outdir)
-            print >>sys.stderr, "- Reading {}".format(warc_file)
-            print >>sys.stderr, "  Writing {}".format(out_file)
+            print("- Reading {}".format(warc_file), file=sys.stderr)
+            print("  Writing {}".format(out_file), file=sys.stderr)
             with open(out_file, 'wb') as outf:
                 p = run_cdx_writer(warc_file, outf, args.warcdir)
                 rc = p.wait()
@@ -136,8 +137,8 @@ if __name__ == "__main__":
                                    re.sub(r'.w?arc\.gz$', '.cdx', w['fn']))
             out_file = os.path.join(args.datadir,
                                     re.sub(r'.w?arc\.gz$', '.exp', w['fn']))
-            print >>sys.stderr, "- Reading {}".format(in_file)
-            print >>sys.stderr, "  Writing {}".format(out_file)
+            print("- Reading {}".format(in_file), file=sys.stderr)
+            print("  Writing {}".format(out_file), file=sys.stderr)
             hashcdx(in_file, out_file)
 
     def download_warcs(args):
@@ -150,7 +151,7 @@ if __name__ == "__main__":
             cmd = ("curl -b %s -L -o %s -w '%%{http_code}'"
                    " https://archive.org/download/%s" % (
                     args.cookie, warc_file, w['fn']))
-            print >>sys.stderr, "Running %s" % (cmd,)
+            print("Running %s" % (cmd,), file=sys.stderr)
             status, output = commands.getstatusoutput(cmd)
             assert status == 0, "Download failed with status=%d" % (status,)
 
@@ -168,7 +169,7 @@ if __name__ == "__main__":
                 )
             sys.stderr.write("OK\n")
             fcount += 1
-        print >>sys.stderr, "Downloaded %d files in %s" % (fcount, args.warcdir)
+        print("Downloaded %d files in %s" % (fcount, args.warcdir), file=sys.stderr)
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-w", "--warcdir", default=warc_dir)

--- a/tests/test_small_warcs.py
+++ b/tests/test_small_warcs.py
@@ -105,7 +105,7 @@ datadir = testdir / "small_warcs"
 sys.path[0:0] = (str(testdir / '..'),)
 cdx_writer = __import__('cdx_writer')
 
-@pytest.mark.parametrize(["file", "expected"], warcs_all_records.iteritems())
+@pytest.mark.parametrize(["file", "expected"], warcs_all_records.items())
 def test_all_records(file, expected, tmpdir):
     '''Test `cdx_writer.py --all-records WARC`.'''
     assert datadir.join(file).exists()
@@ -124,7 +124,7 @@ def test_all_records(file, expected, tmpdir):
     assert 0 == status
     assert output == expected
 
-@pytest.mark.parametrize(["file", "expected"], warcs_defaults.iteritems())
+@pytest.mark.parametrize(["file", "expected"], warcs_defaults.items())
 def test_defaults(file, expected, tmpdir):
     '''Test `cdx_writer.py WARC`.'''
     assert datadir.join(file).exists()


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.